### PR TITLE
feat: load Supabase config from env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Environment variables
+.env
+.env.*
+!env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/env.example
+++ b/env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,10 +2,10 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://hgunnubcxkzcpzutsagn.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhndW5udWJjeGt6Y3B6dXRzYWduIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Mzg2ODA3MjIsImV4cCI6MjA1NDI1NjcyMn0.En-J-VHrzibCBBLsElmayl8VLFPPsyHiIl5bjw6PGz4";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY);
+export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- use Vite env vars for Supabase URL and anon key
- document required env keys
- ignore local `.env` files

## Testing
- `npm test` *(fails: Error when mocking modules)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7938915f4833389d765b262cecae2